### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,6 @@
 name: Pull request workflow
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rtivital/ts-package-template/security/code-scanning/1](https://github.com/rtivital/ts-package-template/security/code-scanning/1)

To fix this problem, add a `permissions` block specifying the minimum necessary permissions at the workflow or job level. Since this workflow simply checks out code, installs dependencies, and runs tests, only `contents: read` is needed. The cleanest fix is to add `permissions: contents: read` near the top of the YAML file (right after the `name:` block), so it applies to the entire workflow and all jobs unless overridden.

- Insert the following block after the workflow `name` (i.e., after line 1 or before line 3):  
  ```yaml
  permissions:
    contents: read
  ```
- No additional methods, imports, or definitions are required.
- No new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
